### PR TITLE
One char fix to make it install with portphp 1.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://docs.portphp.org"
     },
     "require": {
-        "portphp/portphp": "1.2.0",
+        "portphp/portphp": "^1.2.0",
         "doctrine/dbal": "^2.4"
     },
     "autoload": {


### PR DESCRIPTION
Installing dbal with portphp 1.3.0 has an issue:

> /web/utils/avro > composer require portphp/dbal
> Using version ^1.0 for portphp/dbal
> ./composer.json has been updated
> Loading composer repositories with package information
> Updating dependencies (including require-dev)
> Your requirements could not be resolved to an installable set of packages.
> 
>   Problem 1
>     - Installation request for portphp/dbal ^1.0 -> satisfiable by portphp/dbal[1.0.0].
>     - portphp/dbal 1.0.0 requires portphp/portphp 1.2.0 -> satisfiable by portphp/portphp[1.2.0] but these conflict with your requirements or minimum-stability.
> 
> 
> Installation failed, reverting ./composer.json to its original content.

This is a one char fix